### PR TITLE
9C-177: Fixes a failing test in ThemeProcessSpec

### DIFF
--- a/modules/process/src/test/scala/com/fortysevendeg/ninecardslauncher/process/theme/ThemeProcessData.scala
+++ b/modules/process/src/test/scala/com/fortysevendeg/ninecardslauncher/process/theme/ThemeProcessData.scala
@@ -18,11 +18,11 @@ trait ThemeProcessData {
       |  "styles": [
       |    {
       |      "styleType": "SearchBackgroundColor",
-      |      "color": $sampleColorWithoutAlpha
+      |      "color": "$sampleColorWithoutAlpha"
       |    },
       |    {
       |      "styleType": "SearchPressedColor",
-      |      "color": $sampleColorWithAlpha
+      |      "color": "$sampleColorWithAlpha"
       |    },
       |    {
       |      "styleType": "SearchGoogleColor",


### PR DESCRIPTION
This PR fixes a failing test in ThemProcessSpec caused by a value in JSON test which is not in quotes.

@fedefernandez Could you review please? Thanks
