### PR TITLE
9C-200 Migrate ImageServices to ResultT

### DIFF
--- a/modules/services/src/test/scala/com/fortysevendeg/ninecardslauncher/services/image/impl/ImageServicesImplSpec.scala
+++ b/modules/services/src/test/scala/com/fortysevendeg/ninecardslauncher/services/image/impl/ImageServicesImplSpec.scala
@@ -8,11 +8,11 @@ import android.graphics.Bitmap
 import android.util.DisplayMetrics
 import com.fortysevendeg.ninecardslauncher.commons.contexts.ContextSupport
 import com.fortysevendeg.ninecardslauncher.commons.services.Service
-import com.fortysevendeg.ninecardslauncher.services.image.{AppWebsitePath, AppPackagePath, BitmapTransformationException}
+import com.fortysevendeg.ninecardslauncher.services.image.BitmapTransformationException
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-import rapture.core.{Errata, Answer, Result}
+import rapture.core.{Answer, Errata, Result}
 
 import scalaz.concurrent.Task
 
@@ -20,7 +20,9 @@ trait ImageServicesImplSpecification
   extends Specification
   with Mockito {
 
-  val serviceBitmapException = Service(Task(Result.errata[Bitmap, BitmapTransformationException](BitmapTransformationException(""))))
+  val bitmapException = BitmapTransformationException("")
+
+  val serviceBitmapException = Service(Task(Result.errata[Bitmap, BitmapTransformationException](bitmapException)))
 
   trait ImageServicesScope
     extends Scope
@@ -133,7 +135,7 @@ class ImageServicesImplSpec
     "returns filename when the file exists" in
       new ImageServicesScope with FilesExistsImageServicesScope {
         val result = mockImageService.saveAppIcon(appPackage)(contextSupport).run.run
-        result must beLike[Result[AppPackagePath, IOException with BitmapTransformationException]] {
+        result must beLike {
           case Answer(resultAppPackagePath) =>
             resultAppPackagePath shouldEqual appPackagePath
         }
@@ -143,7 +145,7 @@ class ImageServicesImplSpec
       new ImageServicesScope {
         val result = mockImageService.saveAppIcon(appPackage)(contextSupport).run.run
         there was one(mockTasks).saveBitmap(any[File], any[Bitmap])
-        result must beLike[Result[AppPackagePath, IOException with BitmapTransformationException]] {
+        result must beLike {
           case Answer(resultAppPackagePath) =>
             resultAppPackagePath shouldEqual appPackagePath
         }
@@ -153,9 +155,10 @@ class ImageServicesImplSpec
       new ImageServicesScope with BitmapErrorImageServicesScope {
         val result = mockImageService.saveAppIcon(appPackage)(contextSupport).run.run
         there was exactly(0)(mockTasks).saveBitmap(any[File], any[Bitmap])
-        result must beLike[Result[AppPackagePath, IOException with BitmapTransformationException]] {
-          case Errata(errors) =>
-            errors.length must be_==(1)
+        result must beLike {
+          case Errata(e) => e.headOption must beSome.which {
+            case (_, (_, exception)) => exception shouldEqual bitmapException
+          }
         }
       }
 
@@ -166,7 +169,7 @@ class ImageServicesImplSpec
     "returns filename when the file exists" in
       new ImageServicesScope with FilesExistsImageServicesScope {
         val result = mockImageService.saveAppIcon(appWebsite)(contextSupport).run.run
-        result must beLike[Result[AppWebsitePath, IOException with BitmapTransformationException]] {
+        result must beLike {
           case Answer(resultAppWebsitePath) =>
             resultAppWebsitePath shouldEqual appWebsitePath
         }
@@ -176,7 +179,7 @@ class ImageServicesImplSpec
       new ImageServicesScope {
         val result = mockImageService.saveAppIcon(appWebsite)(contextSupport).run.run
         there was one(mockTasks).saveBitmap(any[File], any[Bitmap])
-        result must beLike[Result[AppWebsitePath, IOException with BitmapTransformationException]] {
+        result must beLike {
           case Answer(resultAppWebsitePath) =>
             resultAppWebsitePath shouldEqual appWebsitePath
         }
@@ -186,9 +189,10 @@ class ImageServicesImplSpec
       new ImageServicesScope with BitmapErrorImageServicesScope {
         val result = mockImageService.saveAppIcon(appWebsite)(contextSupport).run.run
         there was exactly(0)(mockTasks).saveBitmap(any[File], any[Bitmap])
-        result must beLike[Result[AppWebsitePath, IOException with BitmapTransformationException]] {
-          case Errata(errors) =>
-            errors.length must be_==(1)
+        result must beLike {
+          case Errata(e) => e.headOption must beSome.which {
+            case (_, (_, exception)) => exception shouldEqual bitmapException
+          }
         }
       }
 


### PR DESCRIPTION
Improved catching exceptions in Tests

@fedefernandez can you please review? thanks!
