### PR TITLE
New travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ script:
   - sbt ++$TRAVIS_SCALA_VERSION "project process" clean coverage test
   - sbt ++$TRAVIS_SCALA_VERSION "project repository" clean coverage test
   - sbt ++$TRAVIS_SCALA_VERSION "project services" clean coverage test
+after_success:
   - sbt ++$TRAVIS_SCALA_VERSION "project tests" test:coverageAggregate
   - sbt ++$TRAVIS_SCALA_VERSION "project tests" test:codacyCoverage


### PR DESCRIPTION
This PR updates travis to use the new infrastructure, just like [the documentation recommends](http://docs.travis-ci.com/user/migrating-from-legacy/)

Also, the send coverage has been moved to the `after_success` section.

Please @FPerezP could you review? Thanks
