### PR TITLE
Tries to avoid a possible cache problem

### DIFF
--- a/modules/app/src/main/scala/com/fortysevendeg/ninecardslauncher/app/ui/profile/ProfileActivity.scala
+++ b/modules/app/src/main/scala/com/fortysevendeg/ninecardslauncher/app/ui/profile/ProfileActivity.scala
@@ -212,8 +212,10 @@ class ProfileActivity
       onPreTask = () => showLoading
     )
 
-  private[this] def loadUserAccounts(client: GoogleApiClient): Unit =
-    Task.fork(loadAccounts(client).run).resolveAsyncUi(
+  private[this] def loadUserAccounts(
+    client: GoogleApiClient,
+    filterOutResourceIds: Seq[String] = Seq.empty): Unit =
+    Task.fork(loadAccounts(client, filterOutResourceIds).run).resolveAsyncUi(
       onResult = accountSyncs => {
         syncEnabled = true
         setAccountsAdapter(accountSyncs)
@@ -234,7 +236,7 @@ class ProfileActivity
     clientStatuses match {
       case GoogleApiClientStatuses(Some(client)) if client.isConnected =>
         Task.fork(deleteAccountDevice(client, resourceId).run).resolveAsyncUi(
-          onResult = (_) => Ui(loadUserAccounts(client)),
+          onResult = (_) => Ui(loadUserAccounts(client, Seq(resourceId))),
           onException = (_) => showError(R.string.contactUsError, () => deleteDevice(resourceId)),
           onPreTask = () => showLoading)
       case _ => showError(R.string.errorConnectingGoogle, () => tryToConnect())


### PR DESCRIPTION
After the [issue](https://github.com/47deg/nine-cards-v2/issues/417#issuecomment-209391824) noticed by @dominv the only reason that I can find is a Google Drive cache problem.

We can add a filter in the "view" side to filter the deleted device from devices load

@javipacheco @dominv could you take a look? What do you think?
