### PR TITLE
Improves the NineCardsPreferences

### DIFF
--- a/modules/app/src/main/scala/cards/nine/app/ui/collections/CollectionAdapter.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/collections/CollectionAdapter.scala
@@ -10,7 +10,7 @@ import cards.nine.app.ui.commons.ExtraTweaks._
 import cards.nine.app.ui.commons.UiContext
 import cards.nine.app.ui.components.commons.ReorderItemTouchListener
 import cards.nine.app.ui.components.drawables.{BackgroundSelectedDrawable, IconTypes, PathMorphDrawable}
-import cards.nine.app.ui.preferences.commons.{FontSize, IconsSize, NineCardsPreferencesValue, ShowPositionInCards}
+import cards.nine.app.ui.preferences.commons.{FontSize, IconsSize, ShowPositionInCards}
 import cards.nine.commons.ops.SeqOps._
 import cards.nine.models.types.{CardType, EmailCardType, PhoneCardType, SmsCardType}
 import cards.nine.process.commons.models.{Card, Collection}
@@ -35,7 +35,7 @@ case class CollectionAdapter(
   extends RecyclerView.Adapter[ViewHolderCollectionAdapter]
   with ReorderItemTouchListener { self =>
 
-  val showPositions = ShowPositionInCards.readValue(new NineCardsPreferencesValue)
+  val showPositions = ShowPositionInCards.readValue
 
   override def onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolderCollectionAdapter = {
     val view = LayoutInflater.from(parent.getContext).inflate(TR.layout.card_item, parent, false)

--- a/modules/app/src/main/scala/cards/nine/app/ui/collections/CollectionsDetailsActivity.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/collections/CollectionsDetailsActivity.scala
@@ -14,7 +14,7 @@ import cards.nine.app.ui.commons.RequestCodes._
 import cards.nine.app.ui.commons.action_filters.{AppInstalledActionFilter, AppsActionFilter}
 import cards.nine.app.ui.commons.ops.TaskServiceOps._
 import cards.nine.app.ui.commons.{ActivityUiContext, UiContext, UiExtensions}
-import cards.nine.app.ui.preferences.commons.{CircleOpeningCollectionAnimation, CollectionOpeningAnimations, NineCardsPreferencesValue}
+import cards.nine.app.ui.preferences.commons.{CircleOpeningCollectionAnimation, CollectionOpeningAnimations}
 import cards.nine.commons._
 import cards.nine.commons.services.TaskService
 import cards.nine.commons.services.TaskService._
@@ -46,8 +46,6 @@ class CollectionsDetailsActivity
   val defaultStateChanged = false
 
   var firstTime = true
-
-  lazy val preferenceValues = new NineCardsPreferencesValue
 
   val navigation = new NavigationCollections()
 
@@ -114,7 +112,7 @@ class CollectionsDetailsActivity
   }
 
   override def onResume(): Unit = {
-    val anim = CollectionOpeningAnimations.readValue(preferenceValues)
+    val anim = CollectionOpeningAnimations.readValue
     if (firstTime && anim == CircleOpeningCollectionAnimation && anim.isSupported) {
       overridePendingTransition(0, 0)
       firstTime = false

--- a/modules/app/src/main/scala/cards/nine/app/ui/collections/actions/apps/AppsIuActions.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/collections/actions/apps/AppsIuActions.scala
@@ -13,7 +13,7 @@ import cards.nine.app.ui.components.layouts.tweaks.PullToDownViewTweaks._
 import cards.nine.app.ui.components.layouts.tweaks.PullToTabsViewTweaks._
 import cards.nine.app.ui.components.layouts.tweaks.TabsViewTweaks._
 import cards.nine.app.ui.components.layouts.{PullToTabsListener, TabInfo}
-import cards.nine.app.ui.preferences.commons.{AppDrawerSelectItemsInScroller, NineCardsPreferencesValue}
+import cards.nine.app.ui.preferences.commons.{AppDrawerSelectItemsInScroller}
 import cards.nine.commons.services.TaskService
 import cards.nine.commons.services.TaskService.TaskService
 import cards.nine.models.ApplicationData
@@ -33,10 +33,8 @@ trait AppsIuActions
 
   val resistance = 2.4f
 
-  lazy val preferences = new NineCardsPreferencesValue
-
   def initialize(onlyAllApps: Boolean, category: NineCardCategory): TaskService[Unit] = {
-    val selectItemsInScrolling = AppDrawerSelectItemsInScroller.readValue(preferences)
+    val selectItemsInScrolling = AppDrawerSelectItemsInScroller.readValue
     val pullToTabsTweaks = if (onlyAllApps) {
       pdvEnable(false)
     } else {

--- a/modules/app/src/main/scala/cards/nine/app/ui/collections/actions/contacts/ContactsUiActions.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/collections/actions/contacts/ContactsUiActions.scala
@@ -13,7 +13,7 @@ import cards.nine.app.ui.components.layouts.tweaks.PullToDownViewTweaks._
 import cards.nine.app.ui.components.layouts.tweaks.PullToTabsViewTweaks._
 import cards.nine.app.ui.components.layouts.tweaks.TabsViewTweaks._
 import cards.nine.app.ui.components.layouts.{PullToTabsListener, TabInfo}
-import cards.nine.app.ui.preferences.commons.{AppDrawerSelectItemsInScroller, NineCardsPreferencesValue}
+import cards.nine.app.ui.preferences.commons.{AppDrawerSelectItemsInScroller}
 import cards.nine.commons.services.TaskService
 import cards.nine.commons.services.TaskService.TaskService
 import cards.nine.models.Contact
@@ -35,10 +35,8 @@ trait ContactsUiActions
     TabInfo(R.drawable.app_drawer_filter_alphabetical, getString(R.string.contacts_alphabetical)),
     TabInfo(R.drawable.app_drawer_filter_favorites, getString(R.string.contacts_favorites)))
 
-  lazy val preferences = new NineCardsPreferencesValue
-
   def initialize(): TaskService[Unit] = {
-    val selectItemsInScrolling = AppDrawerSelectItemsInScroller.readValue(preferences)
+    val selectItemsInScrolling = AppDrawerSelectItemsInScroller.readValue
     ((scrollerLayout <~ scrollableStyle(colorPrimary)) ~
       (toolbar <~
         dtbInit(colorPrimary) <~

--- a/modules/app/src/main/scala/cards/nine/app/ui/commons/Jobs.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/commons/Jobs.scala
@@ -2,12 +2,12 @@ package cards.nine.app.ui.commons
 
 import android.content.Intent
 import android.support.v7.app.AppCompatActivity
-import cards.nine.app.commons.ContextSupportProvider
 import cards.nine.app.commons.BroadcastDispatcher._
+import cards.nine.app.commons.ContextSupportProvider
 import cards.nine.app.di.{Injector, InjectorImpl}
 import cards.nine.app.ui.commons.AppUtils._
 import cards.nine.app.ui.commons.ops.TaskServiceOps._
-import cards.nine.app.ui.preferences.commons.{NineCardsPreferencesValue, Theme}
+import cards.nine.app.ui.preferences.commons.Theme
 import cards.nine.commons.CatchAll
 import cards.nine.commons.services.TaskService
 import cards.nine.commons.services.TaskService.TaskService
@@ -21,11 +21,9 @@ class Jobs(implicit contextWrapper: ContextWrapper)
 
   implicit lazy val di: Injector = new InjectorImpl
 
-  lazy val preferenceValues = new NineCardsPreferencesValue
-
   @deprecated
   def getTheme: NineCardsTheme =
-    di.themeProcess.getTheme(Theme.getThemeFile(preferenceValues)).resolveNow match {
+    di.themeProcess.getTheme(Theme.getThemeFile).resolveNow match {
       case Right(t) => t
       case Left(e) =>
         AppLog.printErrorMessage(e)
@@ -33,7 +31,7 @@ class Jobs(implicit contextWrapper: ContextWrapper)
     }
 
   def getThemeTask: TaskService[NineCardsTheme] =
-    di.themeProcess.getTheme(Theme.getThemeFile(preferenceValues))
+    di.themeProcess.getTheme(Theme.getThemeFile)
 
   @deprecated
   def sendBroadCast(broadAction: BroadAction): Unit = sendBroadCast(commandType, broadAction)

--- a/modules/app/src/main/scala/cards/nine/app/ui/commons/actions/BaseActionFragment.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/commons/actions/BaseActionFragment.scala
@@ -14,7 +14,7 @@ import cards.nine.app.ui.commons.actions.ActionsSnails._
 import cards.nine.app.ui.commons.ops.TaskServiceOps._
 import cards.nine.app.ui.commons.{FragmentUiContext, UiContext, UiExtensions}
 import cards.nine.app.ui.components.widgets.tweaks.TintableImageViewTweaks._
-import cards.nine.app.ui.preferences.commons.{NineCardsPreferencesValue, Theme}
+import cards.nine.app.ui.preferences.commons.Theme
 import cards.nine.commons._
 import cards.nine.commons.ops.ColorOps._
 import cards.nine.process.theme.models._
@@ -43,10 +43,8 @@ trait BaseActionFragment
 
   implicit lazy val uiContext: UiContext[Fragment] = FragmentUiContext(this)
 
-  lazy val preferenceValues = new NineCardsPreferencesValue
-
   implicit lazy val theme: NineCardsTheme =
-    di.themeProcess.getTheme(Theme.getThemeFile(preferenceValues)).resolveNow match {
+    di.themeProcess.getTheme(Theme.getThemeFile).resolveNow match {
       case Right(t) => t
       case _ => getDefaultTheme
     }

--- a/modules/app/src/main/scala/cards/nine/app/ui/components/layouts/AnimatedWorkSpaces.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/components/layouts/AnimatedWorkSpaces.scala
@@ -8,16 +8,16 @@ import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams._
 import android.view._
 import android.widget.FrameLayout
-import com.fortysevendeg.macroid.extras.ResourcesExtras._
-import com.fortysevendeg.macroid.extras.ViewGroupTweaks._
-import com.fortysevendeg.macroid.extras.ViewTweaks._
 import cards.nine.app.ui.commons.AnimationsUtils._
 import cards.nine.app.ui.commons.CommonsTweak._
 import cards.nine.app.ui.commons.ops.ViewOps._
 import cards.nine.app.ui.components.commons._
 import cards.nine.app.ui.components.layouts.AnimatedWorkSpaces._
-import cards.nine.app.ui.preferences.commons.{AppearBehindWorkspaceAnimation, HorizontalSlideWorkspaceAnimation, NineCardsPreferencesValue, WorkspaceAnimations}
+import cards.nine.app.ui.preferences.commons.{AppearBehindWorkspaceAnimation, HorizontalSlideWorkspaceAnimation, WorkspaceAnimations}
 import cards.nine.commons._
+import com.fortysevendeg.macroid.extras.ResourcesExtras._
+import com.fortysevendeg.macroid.extras.ViewGroupTweaks._
+import com.fortysevendeg.macroid.extras.ViewTweaks._
 import macroid.FullDsl._
 import macroid._
 
@@ -99,7 +99,7 @@ abstract class AnimatedWorkSpaces[Holder <: ViewGroup, Data]
       wire(parentViewThree) <~
       vAddField(positionViewKey, PreviousView)).get), params)).run
 
-  def animationPref = WorkspaceAnimations.readValue(new NineCardsPreferencesValue)
+  def animationPref = WorkspaceAnimations.readValue
 
   def createEmptyView(): Holder
 

--- a/modules/app/src/main/scala/cards/nine/app/ui/components/layouts/TopBarLayout.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/components/layouts/TopBarLayout.scala
@@ -35,8 +35,6 @@ class TopBarLayout(context: Context, attrs: AttributeSet, defStyle: Int)
 
   def this(context: Context, attrs: AttributeSet) = this(context, attrs, 0)
 
-  val preferenceValues = new NineCardsPreferencesValue
-
   lazy val collectionsSearchPanel = Option(findView(TR.launcher_search_panel))
 
   lazy val collectionsBurgerIcon = Option(findView(TR.launcher_burger_icon))
@@ -84,7 +82,7 @@ class TopBarLayout(context: Context, attrs: AttributeSet, defStyle: Int)
     val pressedColor = theme.get(SearchPressedColor)
     val iconBackground = new TopBarMomentBackgroundDrawable
     val edgeBackground = new TopBarMomentEdgeBackgroundDrawable
-    val googleLogoPref = GoogleLogo.readValue(preferenceValues)
+    val googleLogoPref = GoogleLogo.readValue
     val googleLogoTweaks = googleLogoPref match {
       case GoogleLogoTheme =>
         ivSrc(R.drawable.search_bar_logo_google_light) +
@@ -135,7 +133,7 @@ class TopBarLayout(context: Context, attrs: AttributeSet, defStyle: Int)
     }
 
   def reloadMoment(moment: NineCardsMoment)(implicit context: ActivityContextWrapper, theme: NineCardsTheme, presenter: LauncherPresenter): Ui[Any] = {
-    val showClock = ShowClockMoment.readValue(preferenceValues)
+    val showClock = ShowClockMoment.readValue
     val text = if (showClock) {
       s"${moment.getName} ${resGetString(R.string.atHour)}"
     } else moment.getName

--- a/modules/app/src/main/scala/cards/nine/app/ui/launcher/LauncherUiActionsImpl.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/launcher/LauncherUiActionsImpl.scala
@@ -12,7 +12,6 @@ import android.view.{DragEvent, View, WindowManager}
 import android.widget.ImageView
 import cards.nine.app.ui.collections.CollectionsDetailsActivity
 import cards.nine.app.ui.collections.CollectionsDetailsActivity._
-import cards.nine.app.ui.commons.AppUtils._
 import cards.nine.app.ui.commons.CommonsExcerpt._
 import cards.nine.app.ui.commons.CommonsTweak._
 import cards.nine.app.ui.commons.Constants._
@@ -42,10 +41,10 @@ import cards.nine.app.ui.launcher.drag.AppDrawerIconShadowBuilder
 import cards.nine.app.ui.launcher.drawer.DrawerUiActions
 import cards.nine.app.ui.launcher.snails.LauncherSnails._
 import cards.nine.app.ui.launcher.types.{AddItemToCollection, ReorderCollection}
-import cards.nine.app.ui.preferences.commons.{CircleOpeningCollectionAnimation, CollectionOpeningAnimations, NineCardsPreferencesValue}
+import cards.nine.app.ui.preferences.commons.{CircleOpeningCollectionAnimation, CollectionOpeningAnimations}
 import cards.nine.commons._
-import cards.nine.models.{ApplicationData, ConditionWeather, Contact, UnknownCondition, Widget}
 import cards.nine.models.types.{AppCardType, CardType, NineCardsMoment}
+import cards.nine.models._
 import cards.nine.process.commons.models.{Collection, Moment}
 import cards.nine.process.device.models.{LastCallsContact, _}
 import cards.nine.process.device.{GetAppOrder, GetByName}
@@ -68,8 +67,6 @@ trait LauncherUiActionsImpl
   with DrawerUiActions {
 
   self: TypedFindView with Contexts[AppCompatActivity] =>
-
-  lazy val preferenceValues = new NineCardsPreferencesValue
 
   lazy val systemBarsTint = new SystemBarsTint
 
@@ -207,7 +204,7 @@ trait LauncherUiActionsImpl
         intent.putExtra(startPosition, collection.position)
         intent.putExtra(indexColorToolbar, collection.themedColorIndex)
         intent.putExtra(iconToolbar, collection.icon)
-        CollectionOpeningAnimations.readValue(preferenceValues) match {
+        CollectionOpeningAnimations.readValue match {
           case anim@CircleOpeningCollectionAnimation if anim.isSupported =>
             rippleToCollection ~~
               Ui {

--- a/modules/app/src/main/scala/cards/nine/app/ui/launcher/collection/CollectionsUiActions.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/launcher/collection/CollectionsUiActions.scala
@@ -166,7 +166,7 @@ trait CollectionsUiActions
       (menuLauncherSettings <~ On.click {
         goToSettings()
       } <~ On.longClick {
-        Ui(IsDeveloper.convertToDeveloper(preferenceValues)) ~
+        Ui(IsDeveloper.convertToDeveloper) ~
           uiShortToast2(R.string.developerOptionsActivated) ~
           goToSettings() ~
           Ui(true)

--- a/modules/app/src/main/scala/cards/nine/app/ui/launcher/drawer/DrawerUiActions.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/launcher/drawer/DrawerUiActions.scala
@@ -86,7 +86,7 @@ trait DrawerUiActions
   }
 
   protected def initDrawerUi: Ui[_] = {
-    val selectItemsInScrolling = AppDrawerSelectItemsInScroller.readValue(preferenceValues)
+    val selectItemsInScrolling = AppDrawerSelectItemsInScroller.readValue
     (searchBoxView <~
       sbvUpdateContentView(AppsView) <~
       sbvChangeListener(SearchBoxAnimatedListener(
@@ -154,17 +154,17 @@ trait DrawerUiActions
   private[this] def openDrawer(longClick: Boolean) = {
 
     def revealInDrawer(longClick: Boolean): Ui[Future[_]] = {
-      val showKeyboard = AppDrawerLongPressAction.readValue(preferenceValues) == AppDrawerLongPressActionOpenKeyboard && longClick
+      val showKeyboard = AppDrawerLongPressAction.readValue == AppDrawerLongPressActionOpenKeyboard && longClick
       (drawerLayout <~ dlLockedClosedStart <~ dlLockedClosedEnd) ~
         (paginationDrawerPanel <~ reloadPager(0)) ~
         ((drawerContent <~~
-          openAppDrawer(AppDrawerAnimation.readValue(preferenceValues), appDrawerMain)) ~~
+          openAppDrawer(AppDrawerAnimation.readValue, appDrawerMain)) ~~
           (searchBoxView <~
             sbvEnableSearch <~
             (if (showKeyboard) sbvShowKeyboard else Tweak.blank)))
     }
 
-    val loadContacts = AppDrawerLongPressAction.readValue(preferenceValues) == AppDrawerLongPressActionOpenContacts && longClick
+    val loadContacts = AppDrawerLongPressAction.readValue == AppDrawerLongPressActionOpenContacts && longClick
     (if (loadContacts) {
       Ui(
         recycler.getAdapter match {
@@ -235,7 +235,7 @@ trait DrawerUiActions
 
   private[this] def loadContactsAlphabetical: Ui[_] = {
     val maybeDrawable = appTabs.lift(AppsMenuOption(AppsAlphabetical)) map (_.drawable)
-    val favoriteContactsFirst = AppDrawerFavoriteContactsFirst.readValue(preferenceValues)
+    val favoriteContactsFirst = AppDrawerFavoriteContactsFirst.readValue
     loadContactsAndSaveStatus(if (favoriteContactsFirst) ContactsFavorites else ContactsAlphabetical) ~
       (paginationDrawerPanel <~ reloadPager(1)) ~
       (pullToTabsView <~
@@ -285,7 +285,7 @@ trait DrawerUiActions
     (drawerLayout <~ dlUnlockedStart <~ (if (collectionMoment.isDefined) dlUnlockedEnd else Tweak.blank)) ~
       (topBarPanel <~ vVisible) ~
       (searchBoxView <~ sbvClean <~ sbvDisableSearch) ~
-      ((drawerContent <~~ closeAppDrawer(AppDrawerAnimation.readValue(preferenceValues), appDrawerMain)) ~~ resetData(searchIsEmpty))
+      ((drawerContent <~~ closeAppDrawer(AppDrawerAnimation.readValue, appDrawerMain)) ~~ resetData(searchIsEmpty))
   }
 
   protected def addApps(

--- a/modules/app/src/main/scala/cards/nine/app/ui/preferences/NineCardsPreferencesActivity.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/preferences/NineCardsPreferencesActivity.scala
@@ -26,8 +26,6 @@ class NineCardsPreferencesActivity
 
   lazy val jobs = new PreferencesJobs(new PreferencesUiActions(this))
 
-  lazy val nineCardsPreferences = new NineCardsPreferencesValue
-
   override def onCreate(savedInstanceState: Bundle): Unit = {
     super.onCreate(savedInstanceState)
     jobs.initialize().resolveAsync()
@@ -57,7 +55,7 @@ class NineCardsPreferencesActivity
     override def onCreate(savedInstanceState: Bundle) = {
       super.onCreate(savedInstanceState)
 
-      if (IsDeveloper.readValue(nineCardsPreferences)) {
+      if (IsDeveloper.readValue) {
         addPreferencesFromResource(R.xml.preferences_devs_headers)
         findPreference(DeveloperPreferences.name).setOnPreferenceClickListener(preferenceClick(DeveloperPreferences.name, new DeveloperFragment()))
       } else {

--- a/modules/app/src/main/scala/cards/nine/app/ui/preferences/appdrawer/AppDrawerUiActions.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/preferences/appdrawer/AppDrawerUiActions.scala
@@ -11,11 +11,9 @@ import macroid.{ContextWrapper, Ui}
 
 class AppDrawerUiActions(dom: AppDrawerDOM)(implicit contextWrapper: ContextWrapper) {
 
-  lazy val preferenceValues = new NineCardsPreferencesValue
-
   def initialize(): TaskService[Unit] = Ui {
-    reloadLongPressActionText(AppDrawerLongPressAction.readValue(preferenceValues).value)
-    reloadAnimationText(AppDrawerAnimation.readValue(preferenceValues).value)
+    reloadLongPressActionText(AppDrawerLongPressAction.readValue.value)
+    reloadAnimationText(AppDrawerAnimation.readValue.value)
     dom.longPressPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener {
       override def onPreferenceChange(preference: Preference, newValue: scala.Any): Boolean = {
         reloadLongPressActionText(newValue.toString)

--- a/modules/app/src/main/scala/cards/nine/app/ui/preferences/commons/NineCardsPreferences.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/preferences/commons/NineCardsPreferences.scala
@@ -1,5 +1,6 @@
 package cards.nine.app.ui.preferences.commons
 
+import NineCardsPreferencesValue._
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import com.fortysevendeg.macroid.extras.ResourcesExtras._
@@ -52,7 +53,7 @@ sealed trait NineCardsPreferenceValue[T]
   extends NineCardsPreferences {
   val name: String
   val default: T
-  def readValue(pref: NineCardsPreferencesValue): T
+  def readValue(implicit contextWrapper: ContextWrapper): T
 }
 
 // Moments Preferences
@@ -62,7 +63,7 @@ case object ShowClockMoment
   override val name: String = showClockMoment
   override val default: Boolean = false
 
-  override def readValue(pref: NineCardsPreferencesValue): Boolean = pref.getBoolean(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): Boolean = getBoolean(name, default)
 }
 
 // Animations Preferences
@@ -72,11 +73,11 @@ case object SpeedAnimations
   override val name: String = speed
   override val default: SpeedAnimationValue = NormalAnimation
 
-  override def readValue(pref: NineCardsPreferencesValue): SpeedAnimationValue =
-    SpeedAnimationValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): SpeedAnimationValue =
+    SpeedAnimationValue(getString(name, default.value))
 
   def getDuration(implicit contextWrapper: ContextWrapper): Int = {
-    resGetInteger(readValue(new NineCardsPreferencesValue) match {
+    resGetInteger(readValue match {
       case NormalAnimation => R.integer.anim_duration_normal
       case SlowAnimation => R.integer.anim_duration_slow
       case FastAnimation => R.integer.anim_duration_fast
@@ -89,8 +90,8 @@ case object CollectionOpeningAnimations
   override val name: String = collectionOpening
   override val default: CollectionOpeningValue = CircleOpeningCollectionAnimation
 
-  override def readValue(pref: NineCardsPreferencesValue): CollectionOpeningValue =
-    CollectionOpeningValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): CollectionOpeningValue =
+    CollectionOpeningValue(getString(name, default.value))
 }
 
 case object WorkspaceAnimations
@@ -98,8 +99,8 @@ case object WorkspaceAnimations
   override val name: String = workspaceAnimation
   override val default: WorkspaceAnimationValue = HorizontalSlideWorkspaceAnimation
 
-  override def readValue(pref: NineCardsPreferencesValue): WorkspaceAnimationValue =
-    WorkspaceAnimationValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): WorkspaceAnimationValue =
+    WorkspaceAnimationValue(getString(name, default.value))
 }
 
 // App Drawer Preferences
@@ -109,8 +110,8 @@ case object AppDrawerLongPressAction
   override val name: String = appDrawerLongPressAction
   override val default: AppDrawerLongPressActionValue = AppDrawerLongPressActionOpenKeyboard
 
-  override def readValue(pref: NineCardsPreferencesValue): AppDrawerLongPressActionValue =
-    AppDrawerLongPressActionValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): AppDrawerLongPressActionValue =
+    AppDrawerLongPressActionValue(getString(name, default.value))
 }
 
 case object AppDrawerAnimation
@@ -118,8 +119,8 @@ case object AppDrawerAnimation
   override val name: String = appDrawerAnimation
   override val default: AppDrawerAnimationValue = AppDrawerAnimationCircle
 
-  override def readValue(pref: NineCardsPreferencesValue): AppDrawerAnimationValue =
-    AppDrawerAnimationValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): AppDrawerAnimationValue =
+    AppDrawerAnimationValue(getString(name, default.value))
 }
 
 case object AppDrawerFavoriteContactsFirst
@@ -127,7 +128,7 @@ case object AppDrawerFavoriteContactsFirst
   override val name: String = appDrawerFavoriteContacts
   override val default: Boolean = false
 
-  override def readValue(pref: NineCardsPreferencesValue): Boolean = pref.getBoolean(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): Boolean = getBoolean(name, default)
 }
 
 case object AppDrawerSelectItemsInScroller
@@ -135,7 +136,7 @@ case object AppDrawerSelectItemsInScroller
   override val name: String = appDrawerSelectItemsInScroller
   override val default: Boolean = true
 
-  override def readValue(pref: NineCardsPreferencesValue): Boolean = pref.getBoolean(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): Boolean = getBoolean(name, default)
 }
 
 // Look & Feel Preferences
@@ -145,10 +146,10 @@ case object Theme
   override val name: String = theme
   override val default: ThemeValue = ThemeLight
 
-  override def readValue(pref: NineCardsPreferencesValue): ThemeValue =
-    ThemeValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): ThemeValue =
+    ThemeValue(getString(name, default.value))
 
-  def getThemeFile(pref: NineCardsPreferencesValue): String = Theme.readValue(pref) match {
+  def getThemeFile(implicit contextWrapper: ContextWrapper): String = Theme.readValue match {
     case ThemeLight => "theme_light"
     case ThemeDark => "theme_dark"
   }
@@ -159,8 +160,8 @@ case object GoogleLogo
   override val name: String = googleLogo
   override val default: GoogleLogoValue = GoogleLogoTheme
 
-  override def readValue(pref: NineCardsPreferencesValue): GoogleLogoValue =
-    GoogleLogoValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): GoogleLogoValue =
+    GoogleLogoValue(getString(name, default.value))
 }
 
 case object FontSize
@@ -168,11 +169,11 @@ case object FontSize
   override val name: String = fontsSize
   override val default: FontSizeValue = FontSizeMedium
 
-  override def readValue(pref: NineCardsPreferencesValue): FontSizeValue =
-    FontSizeValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): FontSizeValue =
+    FontSizeValue(getString(name, default.value))
 
   def getSizeResource(implicit contextWrapper: ContextWrapper): Int = {
-    readValue(new NineCardsPreferencesValue) match {
+    readValue match {
       case FontSizeSmall => R.dimen.text_medium
       case FontSizeMedium => R.dimen.text_default
       case FontSizeLarge => R.dimen.text_large
@@ -180,7 +181,7 @@ case object FontSize
   }
 
   def getTitleSizeResource(implicit contextWrapper: ContextWrapper): Int = {
-    readValue(new NineCardsPreferencesValue) match {
+    readValue match {
       case FontSizeSmall => R.dimen.text_large
       case FontSizeMedium => R.dimen.text_xlarge
       case FontSizeLarge => R.dimen.text_xxlarge
@@ -188,7 +189,7 @@ case object FontSize
   }
 
   def getContactSizeResource(implicit contextWrapper: ContextWrapper): Int = {
-    readValue(new NineCardsPreferencesValue) match {
+    readValue match {
       case FontSizeSmall => R.dimen.text_default
       case FontSizeMedium => R.dimen.text_large
       case FontSizeLarge => R.dimen.text_xlarge
@@ -202,11 +203,11 @@ case object IconsSize
   override val name: String = iconsSize
   override val default: IconsSizeValue = IconsSizeMedium
 
-  override def readValue(pref: NineCardsPreferencesValue): IconsSizeValue =
-    IconsSizeValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): IconsSizeValue =
+    IconsSizeValue(getString(name, default.value))
 
   def getIconApp(implicit contextWrapper: ContextWrapper): Int = {
-    resGetDimensionPixelSize(readValue(new NineCardsPreferencesValue) match {
+    resGetDimensionPixelSize(readValue match {
       case IconsSizeSmall => R.dimen.size_icon_app_small
       case IconsSizeMedium => R.dimen.size_icon_app_medium
       case IconsSizeLarge => R.dimen.size_icon_app_large
@@ -214,7 +215,7 @@ case object IconsSize
   }
 
   def getIconCollection(implicit contextWrapper: ContextWrapper): Int = {
-    resGetDimensionPixelSize(readValue(new NineCardsPreferencesValue) match {
+    resGetDimensionPixelSize(readValue match {
       case IconsSizeSmall => R.dimen.size_group_collection_small
       case IconsSizeMedium => R.dimen.size_group_collection_medium
       case IconsSizeLarge => R.dimen.size_group_collection_large
@@ -228,11 +229,11 @@ case object CardPadding
   override val name: String = cardPadding
   override val default: IconsSizeValue = IconsSizeMedium
 
-  override def readValue(pref: NineCardsPreferencesValue): IconsSizeValue =
-    IconsSizeValue(pref.getString(name, default.value))
+  override def readValue(implicit contextWrapper: ContextWrapper): IconsSizeValue =
+    IconsSizeValue(getString(name, default.value))
 
   def getPadding(implicit contextWrapper: ContextWrapper): Int = {
-    resGetDimensionPixelSize(readValue(new NineCardsPreferencesValue) match {
+    resGetDimensionPixelSize(readValue match {
       case IconsSizeSmall => R.dimen.card_padding_small
       case IconsSizeMedium => R.dimen.card_padding_medium
       case IconsSizeLarge => R.dimen.card_padding_large
@@ -247,9 +248,9 @@ case object IsDeveloper
   override val name: String = isDeveloper
   override val default: Boolean = false
 
-  override def readValue(pref: NineCardsPreferencesValue): Boolean = pref.getBoolean(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): Boolean = getBoolean(name, default)
 
-  def convertToDeveloper(pref: NineCardsPreferencesValue): Unit = pref.setBoolean(name, value = true)
+  def convertToDeveloper(implicit contextWrapper: ContextWrapper): Unit = setBoolean(name, value = true)
 }
 
 case object AppsCategorized
@@ -257,7 +258,7 @@ case object AppsCategorized
   override val name: String = appsCategorized
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object AndroidToken
@@ -265,7 +266,7 @@ case object AndroidToken
   override val name: String = androidToken
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object DeviceCloudId
@@ -273,7 +274,7 @@ case object DeviceCloudId
   override val name: String = deviceCloudId
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object ProbablyActivity
@@ -281,7 +282,7 @@ case object ProbablyActivity
   override val name: String = probablyActivity
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object Headphones
@@ -289,7 +290,7 @@ case object Headphones
   override val name: String = headphones
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object Location
@@ -297,7 +298,7 @@ case object Location
   override val name: String = location
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object Weather
@@ -305,7 +306,7 @@ case object Weather
   override val name: String = weather
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object ClearCacheImages
@@ -313,7 +314,7 @@ case object ClearCacheImages
   override val name: String = clearCacheImages
   override val default: String = ""
 
-  override def readValue(pref: NineCardsPreferencesValue): String = pref.getString(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): String = getString(name, default)
 }
 
 case object ShowPositionInCards
@@ -321,7 +322,7 @@ case object ShowPositionInCards
   override val name: String = showPositionInCards
   override val default: Boolean = false
 
-  override def readValue(pref: NineCardsPreferencesValue): Boolean = pref.getBoolean(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): Boolean = getBoolean(name, default)
 }
 
 case object ShowPrintInfoOptionInAccounts
@@ -329,28 +330,34 @@ case object ShowPrintInfoOptionInAccounts
   override val name: String = showPrintInfoOptionInAccounts
   override val default: Boolean = false
 
-  override def readValue(pref: NineCardsPreferencesValue): Boolean = pref.getBoolean(name, default)
+  override def readValue(implicit contextWrapper: ContextWrapper): Boolean = getBoolean(name, default)
 }
 
 
 // Commons
 
-class NineCardsPreferencesValue(implicit contextWrapper: ContextWrapper) {
+object NineCardsPreferencesValue {
 
-  private[this] def get[T](f: (SharedPreferences) => T) =
+  private[this] def get[T](f: (SharedPreferences) => T)(implicit contextWrapper: ContextWrapper) =
     f(PreferenceManager.getDefaultSharedPreferences(contextWrapper.application))
 
-  def getInt(name: String, defaultValue: Int): Int = get(_.getInt(name, defaultValue))
+  def getInt(name: String, defaultValue: Int)(implicit contextWrapper: ContextWrapper): Int =
+    get(_.getInt(name, defaultValue))
 
-  def setInt(name: String, value: Int): Unit = get(_.edit().putInt(name, value).apply())
+  def setInt(name: String, value: Int)(implicit contextWrapper: ContextWrapper): Unit =
+    get(_.edit().putInt(name, value).apply())
 
-  def getString(name: String, defaultValue: String): String = get(_.getString(name, defaultValue))
+  def getString(name: String, defaultValue: String)(implicit contextWrapper: ContextWrapper): String =
+    get(_.getString(name, defaultValue))
 
-  def setString(name: String, value: String): Unit = get(_.edit().putString(name, value).apply())
+  def setString(name: String, value: String)(implicit contextWrapper: ContextWrapper): Unit =
+    get(_.edit().putString(name, value).apply())
 
-  def getBoolean(name: String, defaultValue: Boolean): Boolean = get(_.getBoolean(name, defaultValue))
+  def getBoolean(name: String, defaultValue: Boolean)(implicit contextWrapper: ContextWrapper): Boolean =
+    get(_.getBoolean(name, defaultValue))
 
-  def setBoolean(name: String, value: Boolean): Unit = get(_.edit().putBoolean(name, value).apply())
+  def setBoolean(name: String, value: Boolean)(implicit contextWrapper: ContextWrapper): Unit =
+    get(_.edit().putBoolean(name, value).apply())
 
 }
 

--- a/modules/app/src/main/scala/cards/nine/app/ui/profile/adapters/AccountsAdapter.scala
+++ b/modules/app/src/main/scala/cards/nine/app/ui/profile/adapters/AccountsAdapter.scala
@@ -2,19 +2,19 @@ package cards.nine.app.ui.profile.adapters
 
 import android.support.v7.widget.RecyclerView
 import android.view.{LayoutInflater, View, ViewGroup}
+import cards.nine.app.ui.commons.CommonsTweak._
+import cards.nine.app.ui.commons.UiContext
+import cards.nine.app.ui.preferences.commons.ShowPrintInfoOptionInAccounts
+import cards.nine.app.ui.profile.AccountsAdapterStyles
+import cards.nine.app.ui.profile.adapters.AccountOptions._
+import cards.nine.app.ui.profile.models.{AccountSync, Device, Header}
+import cards.nine.process.theme.models.NineCardsTheme
 import com.fortysevendeg.macroid.extras.ImageViewTweaks._
 import com.fortysevendeg.macroid.extras.ResourcesExtras._
 import com.fortysevendeg.macroid.extras.TextTweaks._
-import cards.nine.app.ui.commons.CommonsTweak._
-import cards.nine.app.ui.commons.UiContext
-import cards.nine.app.ui.preferences.commons.{NineCardsPreferencesValue, ShowPrintInfoOptionInAccounts}
-import cards.nine.app.ui.profile.adapters.AccountOptions._
-import cards.nine.app.ui.profile.AccountsAdapterStyles
-import cards.nine.app.ui.profile.models.{AccountSync, Device, Header}
-import cards.nine.process.theme.models.NineCardsTheme
 import com.fortysevendeg.ninecardslauncher.{R, TR, TypedFindView}
-import macroid._
 import macroid.FullDsl._
+import macroid._
 
 case class AccountsAdapter(
   items: Seq[AccountSync],
@@ -91,7 +91,7 @@ case class ViewHolderAccountItemAdapter(
 
   lazy val printDriveInfo = (PrintInfoOption, resGetString(R.string.menuAccountPrintInfo))
 
-  lazy val showPrintDriveInfo = ShowPrintInfoOptionInAccounts.readValue(new NineCardsPreferencesValue)
+  lazy val showPrintDriveInfo = ShowPrintInfoOptionInAccounts.readValue
 
   lazy val subtitle = findView(TR.profile_account_subtitle)
 


### PR DESCRIPTION
We don't need the `NineCardsPreferencesValue` at all so I've removed the `class` and just add the  `implicit` `ContextWrapper` to the method `readValue`

Please @javipacheco could you review? Thanks
